### PR TITLE
Add mostrecent aggregation to Gauge

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -346,7 +346,7 @@ class Gauge(MetricWrapperBase):
         d.set_function(lambda: len(my_dict))
     """
     _type = 'gauge'
-    _MULTIPROC_MODES = frozenset(('all', 'liveall', 'min', 'livemin', 'max', 'livemax', 'sum', 'livesum'))
+    _MULTIPROC_MODES = frozenset(('all', 'liveall', 'min', 'livemin', 'max', 'livemax', 'sum', 'livesum', 'mostrecent', 'livemostrecent'))
 
     def __init__(self,
                  name: str,
@@ -357,7 +357,7 @@ class Gauge(MetricWrapperBase):
                  unit: str = '',
                  registry: Optional[CollectorRegistry] = REGISTRY,
                  _labelvalues: Optional[Sequence[str]] = None,
-                 multiprocess_mode: Literal['all', 'liveall', 'min', 'livemin', 'max', 'livemax', 'sum', 'livesum'] = 'all',
+                 multiprocess_mode: Literal['all', 'liveall', 'min', 'livemin', 'max', 'livemax', 'sum', 'livesum', 'mostrecent', 'livemostrecent'] = 'all',
                  ):
         self._multiprocess_mode = multiprocess_mode
         if multiprocess_mode not in self._MULTIPROC_MODES:
@@ -390,10 +390,15 @@ class Gauge(MetricWrapperBase):
         self._raise_if_not_observable()
         self._value.inc(-amount)
 
-    def set(self, value: float) -> None:
-        """Set gauge to the given value."""
+    def set(self, value: float, timestamp_sec: Optional[float] = None) -> None:
+        """Set gauge to the given value.
+
+        This can take an optional timestamp to indicate when the sample was
+        taken. This is used for the most_recent aggregation and Prometheus
+        exposition.
+        """
         self._raise_if_not_observable()
-        self._value.set(float(value))
+        self._value.set(float(value), timestamp_sec=timestamp_sec)
 
     def set_to_current_time(self) -> None:
         """Set gauge to the current unixtime."""

--- a/prometheus_client/mmap_dict.py
+++ b/prometheus_client/mmap_dict.py
@@ -6,17 +6,18 @@ from typing import List
 
 _INITIAL_MMAP_SIZE = 1 << 16
 _pack_integer_func = struct.Struct(b'i').pack
-_pack_double_func = struct.Struct(b'd').pack
+_pack_two_doubles_func = struct.Struct(b'dd').pack
 _unpack_integer = struct.Struct(b'i').unpack_from
-_unpack_double = struct.Struct(b'd').unpack_from
+_unpack_two_doubles = struct.Struct(b'dd').unpack_from
 
 
 # struct.pack_into has atomicity issues because it will temporarily write 0 into
 # the mmap, resulting in false reads to 0 when experiencing a lot of writes.
 # Using direct assignment solves this issue.
 
-def _pack_double(data, pos, value):
-    data[pos:pos + 8] = _pack_double_func(value)
+
+def _pack_two_doubles(data, pos, value, timestamp_sec):
+    data[pos:pos + 16] = _pack_two_doubles_func(value, timestamp_sec)
 
 
 def _pack_integer(data, pos, value):
@@ -24,7 +25,7 @@ def _pack_integer(data, pos, value):
 
 
 def _read_all_values(data, used=0):
-    """Yield (key, value, pos). No locking is performed."""
+    """Yield (key, value, timestamp_sec, pos). No locking is performed."""
 
     if used <= 0:
         # If not valid `used` value is passed in, read it from the file.
@@ -41,9 +42,9 @@ def _read_all_values(data, used=0):
         encoded_key = data[pos:pos + encoded_len]
         padded_len = encoded_len + (8 - (encoded_len + 4) % 8)
         pos += padded_len
-        value = _unpack_double(data, pos)[0]
-        yield encoded_key.decode('utf-8'), value, pos
-        pos += 8
+        value, timestamp_sec = _unpack_two_doubles(data, pos)
+        yield encoded_key.decode('utf-8'), value, timestamp_sec, pos
+        pos += 16
 
 
 class MmapedDict:
@@ -53,7 +54,8 @@ class MmapedDict:
     Then 4 bytes of padding.
     There's then a number of entries, consisting of a 4 byte int which is the
     size of the next field, a utf-8 encoded string key, padding to a 8 byte
-    alignment, and then a 8 byte float which is the value.
+    alignment, and then a 8 byte float which is the value and a 8 byte float
+    which is a UNIX timestamp in seconds.
 
     Not thread safe.
     """
@@ -76,7 +78,7 @@ class MmapedDict:
             _pack_integer(self._m, 0, self._used)
         else:
             if not read_mode:
-                for key, _, pos in self._read_all_values():
+                for key, _, _, pos in self._read_all_values():
                     self._positions[key] = pos
 
     @staticmethod
@@ -95,7 +97,7 @@ class MmapedDict:
         encoded = key.encode('utf-8')
         # Pad to be 8-byte aligned.
         padded = encoded + (b' ' * (8 - (len(encoded) + 4) % 8))
-        value = struct.pack(f'i{len(padded)}sd'.encode(), len(encoded), padded, 0.0)
+        value = struct.pack(f'i{len(padded)}sdd'.encode(), len(encoded), padded, 0.0, 0.0)
         while self._used + len(value) > self._capacity:
             self._capacity *= 2
             self._f.truncate(self._capacity)
@@ -105,30 +107,28 @@ class MmapedDict:
         # Update how much space we've used.
         self._used += len(value)
         _pack_integer(self._m, 0, self._used)
-        self._positions[key] = self._used - 8
+        self._positions[key] = self._used - 16
 
     def _read_all_values(self):
         """Yield (key, value, pos). No locking is performed."""
         return _read_all_values(data=self._m, used=self._used)
 
     def read_all_values(self):
-        """Yield (key, value). No locking is performed."""
-        for k, v, _ in self._read_all_values():
-            yield k, v
+        """Yield (key, value, timestamp_sec). No locking is performed."""
+        for k, v, ts, _ in self._read_all_values():
+            yield k, v, ts
 
     def read_value(self, key):
         if key not in self._positions:
             self._init_value(key)
         pos = self._positions[key]
-        # We assume that reading from an 8 byte aligned value is atomic
-        return _unpack_double(self._m, pos)[0]
+        return _unpack_two_doubles(self._m, pos)
 
-    def write_value(self, key, value):
+    def write_value(self, key, value, timestamp_sec):
         if key not in self._positions:
             self._init_value(key)
         pos = self._positions[key]
-        # We assume that writing to an 8 byte aligned value is atomic
-        _pack_double(self._m, pos, value)
+        _pack_two_doubles(self._m, pos, value, timestamp_sec)
 
     def close(self):
         if self._f:

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -185,6 +185,26 @@ class TestMultiProcess(unittest.TestCase):
         mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
         self.assertEqual(2, self.registry.get_sample_value('g'))
 
+    def test_gauge_mostrecent(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='mostrecent')
+        values.ValueClass = MultiProcessValue(lambda: 456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='mostrecent')
+        g1.set(1, 2000)
+        g2.set(2, 1000)
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+
+    def test_gauge_livemostrecent(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livemostrecent')
+        values.ValueClass = MultiProcessValue(lambda: 456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livemostrecent')
+        g1.set(1, 2000)
+        g2.set(2, 1000)
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+
     def test_namespace_subsystem(self):
         c1 = Counter('c', 'help', registry=None, namespace='ns', subsystem='ss')
         c1.inc(1)
@@ -369,28 +389,28 @@ class TestMmapedDict(unittest.TestCase):
         self.d = mmap_dict.MmapedDict(self.tempfile)
 
     def test_process_restart(self):
-        self.d.write_value('abc', 123.0)
+        self.d.write_value('abc', 123.0, 987.0)
         self.d.close()
         self.d = mmap_dict.MmapedDict(self.tempfile)
-        self.assertEqual(123, self.d.read_value('abc'))
-        self.assertEqual([('abc', 123.0)], list(self.d.read_all_values()))
+        self.assertEqual((123, 987.0), self.d.read_value('abc'))
+        self.assertEqual([('abc', 123.0, 987.0)], list(self.d.read_all_values()))
 
     def test_expansion(self):
         key = 'a' * mmap_dict._INITIAL_MMAP_SIZE
-        self.d.write_value(key, 123.0)
-        self.assertEqual([(key, 123.0)], list(self.d.read_all_values()))
+        self.d.write_value(key, 123.0, 987.0)
+        self.assertEqual([(key, 123.0, 987.0)], list(self.d.read_all_values()))
 
     def test_multi_expansion(self):
         key = 'a' * mmap_dict._INITIAL_MMAP_SIZE * 4
-        self.d.write_value('abc', 42.0)
-        self.d.write_value(key, 123.0)
-        self.d.write_value('def', 17.0)
+        self.d.write_value('abc', 42.0, 987.0)
+        self.d.write_value(key, 123.0, 876.0)
+        self.d.write_value('def', 17.0, 765.0)
         self.assertEqual(
-            [('abc', 42.0), (key, 123.0), ('def', 17.0)],
+            [('abc', 42.0, 987.0), (key, 123.0, 876.0), ('def', 17.0, 765.0)],
             list(self.d.read_all_values()))
 
     def test_corruption_detected(self):
-        self.d.write_value('abc', 42.0)
+        self.d.write_value('abc', 42.0, 987.0)
         # corrupt the written data
         self.d._m[8:16] = b'somejunk'
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
In the multiprocess mode, the process that expose the metrics need to
aggregate the samples from other processes. Gauge metric allows users to
choose the aggregation mode. This implements 'mostrecent' (and
'livemostrecent') mode where the last observed value is exposed.

In order to support this, the file format is expanded to store the
timestamps in addition to the values. The stored timestamps are read by
the reader process and it's used to find the latest value.

The timestamp itself is exposed as a part of Prometheus exposition
(https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).
This allows further aggregation across exporters.

Closes https://github.com/prometheus/client_python/issues/847

Consideration on the atomicity:

Previously, mmap_dict.py had a comment saying "We assume that reading
from an 8 byte aligned value is atomic". With this change, the value
write becomes a 16 bytes 8-byte aligned write. The code author tried to
find a basis on the original assumption, but couldn't find any.
According to write(2), **if a file descriptor is shared**, the write
becomes atomic. However, we do not share the file descriptors in the
current architecture.

Considering that Ruby implementation also does the same and hadn't seen
an issue with it, this write atomicity problem might be practically not
an issue.

See also:

* https://github.com/prometheus/client_ruby/pull/172

  The approach and naming are taken from client_ruby.

* https://github.com/prometheus/client_golang/blob/v1.17.0/prometheus/metric.go#L149-L161

  client_golang has an API for setting timestamp already. It explains
  the use case for the timestamp beyond the client-local aggregation. In
  order to support the same use case in Python, further changes are
  needed.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
